### PR TITLE
Disable TLS on the block puller to work with ORDERER_GENERAL_TLS_ENAB…

### DIFF
--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -841,8 +841,13 @@ func (r *Registrar) createFollower(
 	channelID string,
 ) (*follower.Chain, types.ChannelInfo, error) {
 	fLog := flogging.MustGetLogger("orderer.commmon.follower")
+	dialerConfig := r.clusterDialer.Config.Clone()
+	dialerConfig.SecOpts.UseTLS = false;
+	pullerDialer := &cluster.PredicateDialer{
+		Config: dialerConfig,
+	}
 	blockPullerCreator, err := follower.NewBlockPullerCreator(
-		channelID, fLog, r.signer, r.clusterDialer, r.config.General.Cluster, r.bccsp)
+		channelID, fLog, r.signer, pullerDialer, r.config.General.Cluster, r.bccsp)
 	if err != nil {
 		return nil, types.ChannelInfo{}, errors.WithMessagef(err, "failed to create BlockPullerFactory for channel %s", channelID)
 	}

--- a/orderer/common/multichannel/registrar.go
+++ b/orderer/common/multichannel/registrar.go
@@ -842,7 +842,8 @@ func (r *Registrar) createFollower(
 ) (*follower.Chain, types.ChannelInfo, error) {
 	fLog := flogging.MustGetLogger("orderer.commmon.follower")
 	dialerConfig := r.clusterDialer.Config.Clone()
-	dialerConfig.SecOpts.UseTLS = false;
+	// the block puller client must follow the TLS config of the target endpoint
+	dialerConfig.SecOpts.UseTLS = r.config.General.TLS.Enabled;
 	pullerDialer := &cluster.PredicateDialer{
 		Config: dialerConfig,
 	}


### PR DESCRIPTION
…LED=false

This allows the orderer to use the client-facing RPC port with TLS disabled. The internal block puller, responsible for replicating blocks from another orderer, targets the same RPC port but was configured to use TLS statically. As a follow-up we could set the value to the TLS_ENABLED configuration.